### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ gem 'active_hash'
 gem 'pry-rails'
 
 gem "aws-sdk-s3", require: false
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -306,6 +309,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -129,6 +129,13 @@ a {
   margin-top: 10px;
   object-fit: contain;
 }
+.error-message {
+  color: red;
+}
+
+.login-flash-message {
+  color: red;
+}
 
 /* メイン */
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,7 +18,7 @@ class Item < ApplicationRecord
     validates :user_id
     validates :image
     with_options numericality: { other_than: 0,
-                                 message: 'Select' } do
+                                 message: 'を選択してください' } do
       validates :category_id
       validates :color_id
       validates :size_id
@@ -28,9 +28,9 @@ class Item < ApplicationRecord
       validates :shipping_day_id
     end
     validates :price, numericality: { only_integer: true,
-                                      message: 'Half-width number' }
+                                      message: 'は半角数字で入力してください' }
   end
   validates :price, numericality: { greater_than_or_equal_to: 300,
                                     less_than_or_equal_to: 9_999_999,
-                                    message: 'Out of setting range' }
+                                    message: 'は¥300〜9,999,999の範囲で設定してください' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,17 +10,17 @@ class User < ApplicationRecord
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
 
   validates :password,        format: { with: PASSWORD_REGEX,
-                                        message: 'Include both letters and numbers' }
+                                        message: 'は半角英字と数字両方を含めて設定してください' }
   with_options presence: true do
     validates :nickname
     validates :last_name, format: { with: /\A[ぁ-んァ-ン一-龥]/,
-                                    message: 'Full-width characters' }
+                                    message: 'は全角で入力して下さい' }
     validates :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/,
-                                     message: 'Full-width characters' }
+                                     message: 'は全角で入力して下さい' }
     validates :last_kana_name, format: { with: /\A[ァ-ヶー－]+\z/,
-                                         message: 'Full-width katakana characters' }
+                                         message: 'は全角カナで入力して下さい' }
     validates :first_kana_name, format: { with: /\A[ァ-ヶー－]+\z/,
-                                          message: 'Full-width katakana characters' }
+                                          message: 'は全角カナで入力して下さい' }
     validates :birthday
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,11 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">ユーザーログイン</h2>
+        <div class='login-flash-message'>
+          <%= flash[:notice] %>
+          <%= flash[:alert] %>
+        </div>
+
         <%= form_with model: @user, url: user_session_path, local: true do |f| %>
 
         <div class="field">

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module HandMatchApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed:
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,22 @@
+ja:
+ activerecord:
+   attributes:
+     user:
+       nickname: ニックネーム
+       last_name: 苗字
+       first_name: 名前
+       last_kana_name: 苗字(カナ)
+       first_kana_name: 名前(カナ)
+       birthday: 誕生日
+     item:
+       name: 作品名
+       explanation: 作品説明
+       image: 画像
+       category_id: カテゴリー
+       color_id: 色
+       size_id: サイズ
+       material_id: 素材
+       delivery_charge_id: 配送料負担
+       prefecture_id: 都道府県
+       shipping_day_id: 発送までの日数
+       price: 販売価格

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,127 +17,127 @@ RSpec.describe Item, type: :model do
       it '画像が空だと作品出品ができないこと' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
 
       it '作品名が空欄では作品出品ができないこと' do
         @item.name = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("作品名を入力してください")
       end
 
       it '作品説明が空欄では作品出品ができないこと' do
         @item.explanation = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Explanation can't be blank")
+        expect(@item.errors.full_messages).to include("作品説明を入力してください")
       end
 
       it 'カテゴリー情報がないと作品出品ができないこと' do
         @item.category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
       end
 
       it 'カテゴリー情報が「---」だと作品出品ができないこと' do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category Select')
+        expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
       end
 
       it '色の情報がないと作品出品ができないこと' do
         @item.color_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Color can't be blank")
+        expect(@item.errors.full_messages).to include("色を選択してください")
       end
 
       it '色の情報が「---」だと商品出品ができないこと' do
         @item.color_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Color Select')
+        expect(@item.errors.full_messages).to include("色を選択してください")
       end
 
       it '素材の情報がないと作品出品ができないこと' do
         @item.material_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Material can't be blank")
+        expect(@item.errors.full_messages).to include("素材を選択してください")
       end
 
       it '素材の情報が「---」だと商品出品ができないこと' do
         @item.material_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Material Select')
+        expect(@item.errors.full_messages).to include("素材を選択してください")
       end
 
       it 'サイズの情報がないと作品出品ができないこと' do
         @item.size_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Size can't be blank")
+        expect(@item.errors.full_messages).to include("サイズを選択してください")
       end
 
       it 'サイズの情報が「---」だと商品出品ができないこと' do
         @item.size_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Size Select')
+        expect(@item.errors.full_messages).to include("サイズを選択してください")
       end
 
       it '配送料の負担についての情報がないと商品出品ができないこと' do
         @item.delivery_charge_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery charge can't be blank")
+        expect(@item.errors.full_messages).to include("配送料負担を選択してください")
       end
 
       it '配送料の負担についての情報が「---」だと商品出品ができないこと' do
         @item.delivery_charge_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Delivery charge Select')
+        expect(@item.errors.full_messages).to include("配送料負担を選択してください")
       end
 
       it '発送元の地域についての情報がないと商品出品ができないこと' do
         @item.prefecture = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item.errors.full_messages).to include("都道府県を選択してください")
       end
 
       it '発送元の地域についての情報が「---」だと商品出品ができないこと' do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture Select')
+        expect(@item.errors.full_messages).to include("都道府県を選択してください")
       end
 
       it '発送までの日数についての情報がないと商品出品ができないこと' do
         @item.shipping_day_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day can't be blank")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
       end
 
       it '発送までの日数についての情報が「---」だと商品出品ができないこと' do
         @item.shipping_day_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping day Select')
+        expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
       end
 
       it '販売価格が空欄だと商品出品ができないこと' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください")
       end
 
       it '販売価格が300円未満だと商品出品ができないこと' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include("販売価格は¥300〜9,999,999の範囲で設定してください")
       end
 
       it '販売価格が9,999,999円を超えると商品出品ができないこと' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include("販売価格は¥300〜9,999,999の範囲で設定してください")
       end
 
       it '販売価格が半角数字でないと商品出品ができないこと' do
         @item.price = '５００'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Half-width number')
+        expect(@item.errors.full_messages).to include("販売価格は半角数字で入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,116 +16,116 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できないこと' do
         @user.nickname = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
 
       it 'emailが空では登録できないこと' do
         @user.email = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
 
       it '重複したemailが存在する場合登録できないこと' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include("Eメールはすでに存在します")
       end
 
       it 'emailが@を含まないと登録できないこと' do
         @user.email = 'hogehogehoge'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include("Eメールは不正な値です")
       end
 
       it 'passwordが空では登録できないこと' do
         @user.password = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
 
       it 'passwordが6文字以上でないと登録できないこと' do
         @user.password = 'hoge'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
 
       it 'passwordは半角英字のみでは登録できないこと' do
         @user.password = 'hogehoge'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+        expect(@user.errors.full_messages).to include("パスワードは半角英字と数字両方を含めて設定してください")
       end
 
       it 'passwordは半角数字のみでは登録できないこと' do
         @user.password = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+        expect(@user.errors.full_messages).to include("パスワードは半角英字と数字両方を含めて設定してください")
       end
 
       it 'password_confirmationが空では登録できないこと' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
 
       it 'passwordとpassword_confirmationの値が一致しないと登録できないこと' do
         @user.password_confirmation = 'hoge12'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
 
       it 'ユーザー本名名字が空では登録できないこと' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字を入力してください")
       end
 
       it 'ユーザー本名名字は、全角（漢字・ひらがな・カタカナ）でないと登録できないこと' do
         @user.last_name = 'hoge'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name Full-width characters')
+        expect(@user.errors.full_messages).to include("苗字は全角で入力して下さい")
       end
 
       it 'ユーザー本名名前が空では登録できないこと' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
 
       it 'ユーザー本名名前は、全角（漢字・ひらがな・カタカナ）でないと登録できないこと' do
         @user.first_name = 'hoge'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name Full-width characters')
+        expect(@user.errors.full_messages).to include("名前は全角で入力して下さい")
       end
 
       it 'ユーザー本名名字フリガナが空では登録できないこと' do
         @user.last_kana_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last kana name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字(カナ)を入力してください")
       end
 
       it 'ユーザー本名名前フリガナが空では登録できないこと' do
         @user.first_kana_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("First kana name can't be blank")
+        expect(@user.errors.full_messages).to include("名前(カナ)を入力してください")
       end
 
       it 'ユーザー本名名字フリガナは、全角カタカナでないと登録できないこと' do
         @user.last_kana_name = 'ほげ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last kana name Full-width katakana characters')
+        expect(@user.errors.full_messages).to include("苗字(カナ)は全角カナで入力して下さい")
       end
 
       it 'ユーザー本名名前フリガナは、全角カタカナでないと登録できないこと' do
         @user.first_kana_name = 'ほげ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First kana name Full-width katakana characters')
+        expect(@user.errors.full_messages).to include("名前(カナ)は全角カナで入力して下さい")
       end
 
       it '生年月日が空では登録できないこと' do
         @user.birthday = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("誕生日を入力してください")
       end
     end
   end


### PR DESCRIPTION
# What
- config/application.rbに日本語環境化のための記述追記
- rails-i18nのgem導入
- config/localesディレクトリに日本語化用localeファイルを作成
- モデル単体テストコードのエラーメッセージ記述を修正

# Why
フォーム入力時のエラーメッセージ日本語化のため